### PR TITLE
T3331-Incluir modulo para Criação de Empresa ( Quick Company Creation Wizard )

### DIFF
--- a/account_multicompany_easy_creation/__manifest__.py
+++ b/account_multicompany_easy_creation/__manifest__.py
@@ -15,5 +15,6 @@
     ],
     'data': [
         'wizards/multicompany_easy_creation.xml',
+        'views/res_company.xml',
     ],
 }

--- a/account_multicompany_easy_creation/i18n/pt_BR.po
+++ b/account_multicompany_easy_creation/i18n/pt_BR.po
@@ -1,0 +1,309 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_multicompany_easy_creation
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 11.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-10-15 12:29+0000\n"
+"PO-Revision-Date: 2019-10-15 12:29+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.ui.view,arch_db:account_multicompany_easy_creation.wizard_multicompany_easy_creation_view_form
+msgid "Accept"
+msgstr "Aceitar"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.ui.view,arch_db:account_multicompany_easy_creation.wizard_multicompany_easy_creation_view_form
+msgid "Account"
+msgstr "Conta"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.ui.view,arch_db:account_multicompany_easy_creation.wizard_multicompany_easy_creation_view_form
+msgid "Accounts"
+msgstr "Contas"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_bank_ids
+msgid "Bank accounts to create"
+msgstr "Contas bancárias a serem criadas"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.ui.view,arch_db:account_multicompany_easy_creation.wizard_multicompany_easy_creation_view_form
+msgid "Banks"
+msgstr "Bancos"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.ui.view,arch_db:account_multicompany_easy_creation.wizard_multicompany_easy_creation_view_form
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_chart_template_id
+#: model:ir.ui.view,arch_db:account_multicompany_easy_creation.wizard_multicompany_easy_creation_view_form
+msgid "Chart Template"
+msgstr "Modelo de Plano"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_new_company_id
+msgid "Company"
+msgstr "Empresa"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_name
+msgid "Company Name"
+msgstr "Nome da Empresa"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.actions.act_window,name:account_multicompany_easy_creation.wizard_multicompany_easy_creation_action
+#: model:ir.ui.menu,name:account_multicompany_easy_creation.multicompany_easy_creation_menu
+msgid "Company easy creation"
+msgstr "Assistente para Criar Empresa"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_bank_wiz_create_uid
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_create_uid
+msgid "Created by"
+msgstr "Criado por"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_bank_wiz_create_date
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_create_date
+msgid "Created on"
+msgstr "Criado em"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_currency_id
+#: model:ir.ui.view,arch_db:account_multicompany_easy_creation.wizard_multicompany_easy_creation_view_form
+msgid "Currency"
+msgstr "Moeda"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_account_expense_categ_id
+msgid "Default Category Expense Account"
+msgstr "Conta de despesa de categoria padrão"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_account_income_categ_id
+msgid "Default Category Income Account"
+msgstr "Conta de renda de categoria padrão"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_account_payable_id
+msgid "Default Payable Account"
+msgstr "Conta a pagar padrão"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_default_purchase_tax_id
+msgid "Default Purchase Tax"
+msgstr "Imposto Padrão de Compra"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_account_receivable_id
+msgid "Default Receivable Account"
+msgstr "Conta a receber padrão"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_default_sale_tax_id
+msgid "Default Sales Tax"
+msgstr "Imposto de vendas padrão"
+
+#. module: account_multicompany_easy_creation
+#: code:addons/account_multicompany_easy_creation/wizards/multicompany_easy_creation.py:208
+#, python-format
+msgid "Description not set in tax template: '%s'"
+msgstr "Descrição não definida no modelo de imposto: '%s'"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_bank_wiz_display_name
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_display_name
+msgid "Display Name"
+msgstr "Nome exibido"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.ui.view,arch_db:account_multicompany_easy_creation.wizard_multicompany_easy_creation_view_form
+msgid "Fill company data"
+msgstr "Preencher dados da empresa"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_force_purchase_tax
+msgid "Force Purchase Tax In All Products"
+msgstr "Forçar imposto de compra em todos os produtos"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_force_sale_tax
+msgid "Force Sale Tax In All Products"
+msgstr "Forçar imposto sobre a venda em todos os produtos"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,help:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_smart_search_fiscal_position
+msgid "Go over partner fiscal positions in actual company to match and set equivalent fiscal positions in the new company."
+msgstr "Examine as posições fiscais dos parceiros na empresa real para corresponder e definir posições fiscais equivalentes na nova empresa."
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,help:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_smart_search_product_tax
+msgid "Go over product taxes in actual company to match and set equivalent taxes in then new company."
+msgstr "Revise os impostos do produto na empresa real para corresponder e definir impostos equivalentes na nova empresa."
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,help:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_smart_search_specific_account
+msgid "Go over specific accounts in actual company to match and set equivalent taxes in the new company.\n"
+"Applies to products, categories, partners, ..."
+msgstr "Consulte as contas específicas da empresa real para corresponder e definir impostos equivalentes na nova empresa.\n"
+"Aplica-se a produtos, categorias, parceiros, ..."
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_bank_wiz_id
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_id
+msgid "ID"
+msgstr "ID"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_bank_wiz___last_update
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz___last_update
+msgid "Last Modified on"
+msgstr "Última modificação em"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_bank_wiz_write_uid
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_write_uid
+msgid "Last Updated by"
+msgstr "Última atualização por"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_bank_wiz_write_date
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_write_date
+msgid "Last Updated on"
+msgstr "Última atualização em"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_accounts_code_digits
+msgid "Number of digits in an account code"
+msgstr "Número de dígitos em um código de conta"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.ui.view,arch_db:account_multicompany_easy_creation.wizard_multicompany_easy_creation_view_form
+msgid "Sequences"
+msgstr "Sequências"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_sequence_ids
+msgid "Sequences to create"
+msgstr "Sequences to create"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,help:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_force_purchase_tax
+msgid "Set default purchase tax to all products.\n"
+"If smart search product tax is also enabled matches founded will overwrite default taxes, but not founded will remain"
+msgstr "Defina o imposto de compra padrão para todos os produtos.\n"
+"Se o imposto do produto de pesquisa inteligente também estiver ativado, as correspondências fundadas substituirão os impostos padrão, mas não fundadas permanecerão"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,help:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_force_sale_tax
+msgid "Set default sales tax to all products.\n"
+"If smart search product tax is also enabled matches founded will overwrite default taxes, but not founded will remain"
+msgstr "Defina o imposto de vendas padrão para todos os produtos.\n"
+"Se o imposto do produto de pesquisa inteligente também estiver ativado, as correspondências fundadas substituirão os impostos padrão, mas não fundadas permanecerão"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_smart_search_fiscal_position
+msgid "Smart Search Fiscal Position"
+msgstr "Posição fiscal da pesquisa inteligente"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_smart_search_product_tax
+msgid "Smart Search Product Tax"
+msgstr "Imposto sobre produtos da Pesquisa inteligente"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_smart_search_specific_account
+msgid "Smart Search Specific Account"
+msgstr "Conta específica da pesquisa inteligente"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.ui.view,arch_db:account_multicompany_easy_creation.wizard_multicompany_easy_creation_view_form
+msgid "Smart search to set product taxes"
+msgstr "Pesquisa inteligente para definir impostos sobre produtos"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.ui.view,arch_db:account_multicompany_easy_creation.wizard_multicompany_easy_creation_view_form
+msgid "Smart search to set specific accounts in products, categories, partners, ..."
+msgstr "Pesquisa inteligente para definir contas específicas em produtos, categorias, parceiros, ..."
+
+#. module: account_multicompany_easy_creation
+#: model:ir.ui.view,arch_db:account_multicompany_easy_creation.wizard_multicompany_easy_creation_view_form
+msgid "Smart search to set specific fiscal position in partners"
+msgstr "Pesquisa inteligente para definir posição fiscal específica em parceiros"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.ui.view,arch_db:account_multicompany_easy_creation.wizard_multicompany_easy_creation_view_form
+msgid "Taxes"
+msgstr "Impostos"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_update_default_accounts
+msgid "Update Default Accounts"
+msgstr "Atualizar contas padrão"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_update_default_taxes
+msgid "Update Default Taxes"
+msgstr "Atualizar impostos padrão"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.ui.view,arch_db:account_multicompany_easy_creation.wizard_multicompany_easy_creation_view_form
+msgid "Update default accounts"
+msgstr "Atualizar contas padrão"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,help:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_update_default_accounts
+msgid "Update default accounts defined in account chart template"
+msgstr "Atualizar contas padrão definidas no modelo de gráfico de contas"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.ui.view,arch_db:account_multicompany_easy_creation.wizard_multicompany_easy_creation_view_form
+msgid "Update default taxes"
+msgstr "Atualizar impostos padrão"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,help:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_update_default_taxes
+msgid "Update default taxes applied to local transactions"
+msgstr "Atualizar impostos padrão aplicados a transações locais"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.ui.view,arch_db:account_multicompany_easy_creation.wizard_multicompany_easy_creation_view_form
+msgid "Users"
+msgstr "Usuários"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_easy_creation_wiz_user_ids
+msgid "Users allowed"
+msgstr "Usuários permitidos"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model.fields,field_description:account_multicompany_easy_creation.field_account_multicompany_bank_wiz_wizard_id
+msgid "Wizard"
+msgstr "Assistente"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model,name:account_multicompany_easy_creation.model_account_multicompany_bank_wiz
+msgid "account.multicompany.bank.wiz"
+msgstr "account.multicompany.bank.wiz"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.model,name:account_multicompany_easy_creation.model_account_multicompany_easy_creation_wiz
+msgid "account.multicompany.easy.creation.wiz"
+msgstr "account.multicompany.easy.creation.wiz"
+
+#. module: account_multicompany_easy_creation
+#: model:ir.ui.view,arch_db:account_multicompany_easy_creation.wizard_multicompany_easy_creation_view_form
+msgid "or"
+msgstr "ou"
+

--- a/account_multicompany_easy_creation/views/res_company.xml
+++ b/account_multicompany_easy_creation/views/res_company.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- 
+        Desabilita o Botão de Criar no Cadastro de Empresa
+        para Forçar sempre a Criação por este Modulo.
+    -->
+
+    <record id="view_company_tree_inherited_create" model="ir.ui.view">
+        <field name="name">res.company.tree.inherited.create</field>
+        <field name="model">res.company</field>
+        <field name="inherit_id" ref="base.view_company_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//tree" position="attributes">
+                <attribute name="create">false</attribute>
+            </xpath>        
+        </field>
+    </record>
+
+    <record id="view_company_form_inherited_create" model="ir.ui.view">
+        <field name="name">view_company_form_inherited.create</field>
+        <field name="model">res.company</field>
+        <field name="inherit_id" ref="base.view_company_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//form" position="attributes">
+                <attribute name="create">false</attribute>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/account_multicompany_easy_creation/wizards/multicompany_easy_creation.py
+++ b/account_multicompany_easy_creation/wizards/multicompany_easy_creation.py
@@ -267,18 +267,24 @@ class AccountMulticompanyEasyCreationWiz(models.TransientModel):
         ])
         Model = self_sudo.env[model]
         for prop in properties:
-            ref = Model.browse(int(prop.value_reference.split(',')[1]))
-            new_ref = Model.search([
-                ('company_id', '=', new_company_id),
-                (match_field, '=', ref[match_field]),
-            ])
-            if new_ref:
-                prop.copy({
-                    'company_id': new_company_id,
-                    'value_reference': '{},{}'.format(model, new_ref.id),
-                    'value_float': False,
-                    'value_integer': False,
-                })
+            # Alteração Multidados
+            # Adiciona try/except para tratar registros excluidos,
+            # porém existentes no ir.properties
+            try:
+                ref = Model.browse(int(prop.value_reference.split(',')[1]))
+                new_ref = Model.search([
+                    ('company_id', '=', new_company_id),
+                    (match_field, '=', ref[match_field]),
+                ])
+                if new_ref:
+                    prop.copy({
+                        'company_id': new_company_id,
+                        'value_reference': '{},{}'.format(model, new_ref.id),
+                        'value_float': False,
+                        'value_integer': False,
+                    })
+            except:  # noqa
+                pass
 
     def match_account(self, account_template):
         code = '{code:0<{fill}}'.format(

--- a/account_multicompany_easy_creation/wizards/multicompany_easy_creation.xml
+++ b/account_multicompany_easy_creation/wizards/multicompany_easy_creation.xml
@@ -18,7 +18,7 @@
                         <field name="currency_id"/>
                     </group>
                     <group string="Chart Template">
-                        <field name="chart_template_id"/>
+                        <field name="chart_template_id" required="1"/>
                         <field name="accounts_code_digits"/>
                     </group>
                     <group col="1" string="Accounts">
@@ -103,6 +103,6 @@
           action="wizard_multicompany_easy_creation_action"
           parent="base.menu_users"
           sequence="180"
-          groups="base.group_no_one"/>
+          groups="base.group_system"/>
 
 </odoo>


### PR DESCRIPTION
# Descrição

[IMP] Modifica modulo para utilização no MultiERP

- Bloqueia o CREATE na Tree e Form do Modulo Company
- Adciona Try/Except para criação de Empresa tratando erros de Registros Apagados
- Modifica Grupo para dar Acesso ao Cadastro da Empresa por este Modulo
- Torna Obrigatória a Informação do Modelo de Plano de Contas
  Obs.: Uso obrigatório pela estrutura criada no MultiERP
- Adiciona Tradução para o Português

# Informações adicionais

[T3331](https://multi.multidadosti.com.br/web#id=3740&view_type=form&model=project.task&action=323&active_id=61)

PR Relacionado: [41](https://github.com/multidadosti-erp/multidadosti-packages-addons/pull/41)