### PR TITLE
T3829-Corrigir build do multi-company

### DIFF
--- a/account_multicompany_easy_creation/wizards/multicompany_easy_creation.xml
+++ b/account_multicompany_easy_creation/wizards/multicompany_easy_creation.xml
@@ -19,7 +19,6 @@
                     </group>
                     <group string="Chart Template">
                         <field name="chart_template_id" required="1"/>
-                        <field name="accounts_code_digits"/>
                     </group>
                     <group col="1" string="Accounts">
                         <group string="Smart search to set specific accounts in products, categories, partners, ...">


### PR DESCRIPTION
* [DEL] Remove campo 'accounts_code_digits'

Campo não existe mais na versão 2.0

[T3829](https://multi.multidadosti.com.br/web#id=4238&view_type=form&model=project.task&action=323&active_id=61)