### PR TITLE
T4087-Permitir que account journal seja multi-company

### DIFF
--- a/base_multi_company/hooks.py
+++ b/base_multi_company/hooks.py
@@ -60,6 +60,7 @@ def post_init_hook(cr, rule_ref, model_name):
             INSERT INTO %s
             (%s, %s)
             SELECT id, company_id FROM %s WHERE company_id IS NOT NULL
+            ON CONFLICT DO NOTHING
         """ % (table_name, column1, column2, model._table)
         env.cr.execute(SQL)
 


### PR DESCRIPTION
# Descrição

[IMP] Adiciona linha na query de insert na tabela para não dar erro de constraints quando a mesma já existir, se houver duplicação de valores, ele ignorará.

# Informações adicionais

[T4087](https://multi.multidadosti.com.br/web#id=4496&view_type=form&model=project.task&action=323&active_id=61)
Depende dos PRs:
https://github.com/multidadosti-erp/multidadosti-packages-addons/pull/48
https://github.com/multidadosti-erp/multidadosti-addons/pull/556