### PR TITLE
T4090-Permitir que crm_lead seja multi-company

### DIFF
--- a/base_multi_company/models/multi_company_abstract.py
+++ b/base_multi_company/models/multi_company_abstract.py
@@ -15,6 +15,8 @@ class MultiCompanyAbstract(models.AbstractModel):
         compute='_compute_company_id',
         inverse='_inverse_company_id',
         search='_search_company_id',
+        store=True,
+        index=True,
     )
     company_ids = fields.Many2many(
         string='Companies',


### PR DESCRIPTION
# Descrição

[IMP] Adiciona o store como True dentro do company_id para ele salvar quando passar pelo compute

# Informações adicionais

[T4090](https://multi.multidadosti.com.br/web#id=4499&view_type=form&model=project.task&action=323&active_id=61)

Depende dos PRs:
https://github.com/multidadosti-erp/multidadosti-addons/pull/558
https://github.com/multidadosti-erp/others-addons/pull/137