### PR TITLE
T4197-Verificar erro do runbot no repo multi_company

### DIFF
--- a/account_invoice_consolidated/__manifest__.py
+++ b/account_invoice_consolidated/__manifest__.py
@@ -27,6 +27,7 @@
         'views/report_consolidated_invoice.xml',
     ],
     'application': True,
+    'installable': False,
     'development_status': 'Beta',
     'maintainers': [
         'max3903',

--- a/account_payment_other_company/__manifest__.py
+++ b/account_payment_other_company/__manifest__.py
@@ -17,6 +17,7 @@
         'views/account_payment.xml',
     ],
     'development_status': 'Beta',
+    'installable': False,
     'maintainers': [
         'max3903',
         'osi-scampbell',

--- a/purchase_sale_inter_company/__manifest__.py
+++ b/purchase_sale_inter_company/__manifest__.py
@@ -14,7 +14,7 @@
               'Tecnativa, '
               'Odoo Community Association (OCA)',
     'license': 'AGPL-3',
-    'installable': True,
+    'installable': False,
     'depends': [
         'sale',
         'purchase',


### PR DESCRIPTION
# Descrição

[IMP] Deixa módulos que não utilizamos como 'não-instalável' para não ter erro no package.

# Informações adicionais

[T4197](https://multi.multidadosti.com.br/web#id=4606&view_type=form&model=project.task&action=323&active_id=61)
